### PR TITLE
Add *.log to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ package-lock.json
 
 # Misc
 .DS_Store
+
+# Log files
+*.log


### PR DESCRIPTION
Add `*.log` to the `.gitignore` file in order to remove possible log files that can be generated, such as `yarn-error.log`.