### PR TITLE
Fix ISO Date instead of Locale Date

### DIFF
--- a/src/scripts/build.ts
+++ b/src/scripts/build.ts
@@ -16,7 +16,7 @@ export default function build(customUpdatedAt: string | undefined): void {
 	const songs = getAllSongs().filter((song) => !song.deleted);
 	const updatedAt = customUpdatedAt?.match(/^\d{4}-(0\d|1[012])-([012]\d|3[01])$/)
 		? customUpdatedAt
-		: new Date().toLocaleDateString();
+		: new Date().toISOString().split('T').at(0);
 
 	writeJson(songs, updatedAt);
 	writeXml(songs, updatedAt);


### PR DESCRIPTION
Uses `toISOString()` instead of `toLocaleDateString()` in order for all computers to give the same string. Otherwise some might output the format such as `mm/dd/yy` or similar.

This Resolves #17 